### PR TITLE
Change name of exported cmake configuration files

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -3,12 +3,12 @@
 include(CMakePackageConfigHelpers)
 
 configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/config.cmake.in
-${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${PROJECT_NAME}-config.cmake
+${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${PROJECT_NAME}Config.cmake
 INSTALL_DESTINATION cmake
 )
 
 write_basic_package_version_file(
-${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${PROJECT_NAME}-config-version.cmake
+${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${PROJECT_NAME}ConfigVersion.cmake
 COMPATIBILITY SameMinorVersion
 )
 
@@ -18,8 +18,8 @@ DESTINATION cmake
 )
 
 install(FILES
-${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${PROJECT_NAME}-config.cmake
-${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${PROJECT_NAME}-config-version.cmake
+${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${PROJECT_NAME}Config.cmake
+${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${PROJECT_NAME}ConfigVersion.cmake
 DESTINATION cmake
 )
 


### PR DESCRIPTION
In "Config mode", CMake's find_package will look for two files:

`<lowercasePackageName>-config.cmake`
  and
`<PackageName>Config.cmake`

(See CMake documentation:
https://cmake.org/cmake/help/latest/command/find_package.html)

However, the MUMPS configuration files were named
"MUMPS-config.cmake", which is none of the above.

This commit changes the names of the configuration files to
MUMPSConfig.cmake and MUMPSConfigVersion.cmake. CMake now seems to
correctly pick up these configuration files in "Config mode".