### PR TITLE
compilers: add `-fno-strict-aliasing` for GNU

### DIFF
--- a/cmake/compilers.cmake
+++ b/cmake/compilers.cmake
@@ -51,7 +51,7 @@ if(CMAKE_C_COMPILER_ID MATCHES "^Intel")
     )
   endif()
 elseif(CMAKE_C_COMPILER_ID STREQUAL "Clang|GNU")
-  add_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror-implicit-function-declaration>)
+  add_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror-implicit-function-declaration;-fno-strict-aliasing>)
 endif()
 
 
@@ -83,7 +83,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "^Intel")
 elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
   add_compile_options(
   $<$<COMPILE_LANGUAGE:Fortran>:-fimplicit-none>
-  "$<$<AND:$<VERSION_GREATER_EQUAL:${CMAKE_Fortran_COMPILER_VERSION},10>,$<COMPILE_LANGUAGE:Fortran>>:-fallow-argument-mismatch;-fallow-invalid-boz>"
+  "$<$<AND:$<VERSION_GREATER_EQUAL:${CMAKE_Fortran_COMPILER_VERSION},10>,$<COMPILE_LANGUAGE:Fortran>>:-fallow-argument-mismatch;-fallow-invalid-boz;-fno-strict-aliasing>"
   )
 
   if(NOT CMAKE_CROSSCOMPILING AND NOT CRAY)


### PR DESCRIPTION
I play around with structural optimization, and that involves repeatedly solving finite element problems. Once, I noticed that my program was leaking memory quite a bit and traced the problem to MUMPS (that is, other solvers didn't have that). However, the MUMPS binaries that Fedora distributes don't leak memory. Playing around with compiler options, I took the compiler's suggestion of adding `-fno-strict-aliasing` and that solved it.

It shouldn't be too hard to reproduce if you want to try it out. I just used a symmetric matrix in serial and maintained the structure while repeatedly changing the values, decomposing, then solving. Matrix size doesn't seem to matter, but larger matrices seem to leak a bit more.