### PR TITLE
Compilation with openblas fixes

### DIFF
--- a/cmake/FindLAPACK.cmake
+++ b/cmake/FindLAPACK.cmake
@@ -220,7 +220,7 @@ endfunction(netlib_libs)
 function(openblas_libs)
 
 find_library(LAPACK_LIBRARY
-NAMES lapack
+NAMES openblas
 PATH_SUFFIXES openblas
 DOC "LAPACK library"
 )

--- a/cmake/compilers.cmake
+++ b/cmake/compilers.cmake
@@ -109,5 +109,10 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS true)
 
 # allow CMAKE_PREFIX_PATH with ~ expand
 if(CMAKE_PREFIX_PATH)
-  get_filename_component(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ABSOLUTE)
+  set(prefix_path "")
+  foreach(path ${CMAKE_PREFIX_PATH})
+    get_filename_component(path "${path}" ABSOLUTE)
+    list(APPEND prefix_path "${path}")
+  endforeach()
+  set(CMAKE_PREFIX_PATH "${prefix_path}")
 endif()

--- a/cmake/mumps.cmake
+++ b/cmake/mumps.cmake
@@ -117,8 +117,10 @@ $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 target_compile_definitions(mumps_common PRIVATE ${ORDERING_DEFS})
+set(BLAS_HAVE_GEMMT FALSE)
 if(BLAS_HAVE_sGEMMT OR BLAS_HAVE_dGEMMT OR BLAS_HAVE_cGEMMT OR BLAS_HAVE_zGEMMT)
   target_compile_definitions(mumps_common PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:GEMMT_AVAILABLE>)
+  set(BLAS_HAVE_GEMMT TRUE)
 endif()
 set_property(TARGET mumps_common PROPERTY EXPORT_NAME COMMON)
 set_property(TARGET mumps_common PROPERTY VERSION ${MUMPS_VERSION})


### PR DESCRIPTION
These are a few fixes in the compilation with OpenBLAS. The issues rectified are the following:

1. Allow multiple directories in CMAKE_PREFIX_PATH, e.g. `-D CMAKE_PREFIX_PATH:PATH="${HOME}/opt/scalapack;${HOME}/opt/openblas"`
2. Link with the correct LAPACK library wehn building with OpenBLAS. [OpenBLAS links BLAS and LAPACK in a single shared object](https://github.com/xianyi/OpenBLAS/issues/203), `libopenblas.so`. [The reference implementation of Netlib is used](https://github.com/xianyi/OpenBLAS/wiki/Developer-manual), with some parts optimized.
3. Report support for `GEMMT` by initializing the flag `BLAS_HAVE_GEMMT`.
