### PR TITLE
Fix CMake configuration for -Dparmetis=on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ if(scotch)
 endif()
 
 if(parmetis)
-  find_package(METIS REQUIRED COMPONENTS parallel)
+  find_package(METIS REQUIRED COMPONENTS ParMETIS)
   list(APPEND ORDERING_DEFS parmetis metis)
   list(APPEND ORDERING_LIBS METIS::METIS)
 elseif(metis)

--- a/cmake/FindMETIS.cmake
+++ b/cmake/FindMETIS.cmake
@@ -26,24 +26,24 @@ METIS_INCLUDE_DIRS
 #]=======================================================================]
 
 
-if(parallel IN_LIST METIS_FIND_COMPONENTS)
+if(ParMETIS IN_LIST METIS_FIND_COMPONENTS)
   find_library(PARMETIS_LIBRARY
-    NAMES parmetis
-    PATH_SUFFIXES METIS libmetis
-    DOC "ParMETIS library"
-    )
+  NAMES parmetis
+  PATH_SUFFIXES METIS libmetis
+  DOC "ParMETIS library"
+  )
   if(PARMETIS_LIBRARY)
-    set(METIS_parallel_FOUND true)
+    set(METIS_ParMETIS_FOUND true)
   endif()
 endif()
 
 find_library(METIS_LIBRARY
-  NAMES metis
-  PATH_SUFFIXES METIS libmetis
-  DOC "METIS library"
-  )
+NAMES metis
+PATH_SUFFIXES METIS libmetis
+DOC "METIS library"
+)
 
-if(parallel IN_LIST METIS_FIND_COMPONENTS)
+if(ParMETIS IN_LIST METIS_FIND_COMPONENTS)
   set(metis_inc parmetis.h)
 else()
   set(metis_inc metis.h)
@@ -55,25 +55,25 @@ PATH_SUFFIXES METIS openmpi-x86_64 mpich-x86_64
 DOC "METIS include directory"
 )
 
+set(METIS_LIBRARIES ${PARMETIS_LIBRARY} ${METIS_LIBRARY})
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(METIS
-REQUIRED_VARS METIS_LIBRARY METIS_INCLUDE_DIR
+REQUIRED_VARS METIS_LIBRARIES METIS_INCLUDE_DIR
 HANDLE_COMPONENTS
 )
 
 if(METIS_FOUND)
+  set(METIS_INCLUDE_DIRS ${METIS_INCLUDE_DIR})
 
-set(METIS_LIBRARIES ${PARMETIS_LIBRARY} ${METIS_LIBRARY})
-set(METIS_INCLUDE_DIRS ${METIS_INCLUDE_DIR})
+  message(VERBOSE "METIS libraries: ${METIS_LIBRARIES}
+  METIS include directories: ${METIS_INCLUDE_DIRS}")
 
-message(VERBOSE "METIS libraries: ${METIS_LIBRARIES}
-METIS include directories: ${METIS_INCLUDE_DIRS}")
-
-if(NOT TARGET METIS::METIS)
-  add_library(METIS::METIS INTERFACE IMPORTED)
-  set_property(TARGET METIS::METIS PROPERTY INTERFACE_LINK_LIBRARIES "${METIS_LIBRARIES}")
-  set_property(TARGET METIS::METIS PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${METIS_INCLUDE_DIR}")
-endif()
+  if(NOT TARGET METIS::METIS)
+    add_library(METIS::METIS INTERFACE IMPORTED)
+    set_property(TARGET METIS::METIS PROPERTY INTERFACE_LINK_LIBRARIES "${METIS_LIBRARIES}")
+    set_property(TARGET METIS::METIS PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${METIS_INCLUDE_DIR}")
+  endif()
 endif(METIS_FOUND)
 
 mark_as_advanced(METIS_INCLUDE_DIR METIS_LIBRARY PARMETIS_LIBRARY)

--- a/cmake/FindScotch.cmake
+++ b/cmake/FindScotch.cmake
@@ -18,7 +18,7 @@
 #  COMPONENTS:
 #
 #  * ESMUMPS: detect Scotch esmumps interface
-#  * parallel: detect parallel (MPI) Scotch
+#  * PTScotch: detect parallel (MPI) Scotch
 #
 # This module finds headers and scotch library.
 # Results are reported in variables:
@@ -61,7 +61,7 @@ if(ESMUMPS IN_LIST Scotch_FIND_COMPONENTS)
   list(INSERT scotch_names 0 esmumps)
 endif()
 
-if(parallel IN_LIST Scotch_FIND_COMPONENTS)
+if(PTScotch IN_LIST Scotch_FIND_COMPONENTS)
   list(INSERT scotch_names 0 ptscotch ptscotcherr)
   if(ESMUMPS IN_LIST Scotch_FIND_COMPONENTS)
     list(INSERT scotch_names 0 ptesmumps)
@@ -79,10 +79,10 @@ foreach(l IN LISTS scotch_names)
   mark_as_advanced(Scotch_${l}_LIBRARY)
 endforeach()
 
-if(parallel IN_LIST Scotch_FIND_COMPONENTS)
+if(PTScotch IN_LIST Scotch_FIND_COMPONENTS)
   if(Scotch_ptesmumps_LIBRARY AND Scotch_ptscotch_LIBRARY)
     set(Scotch_ESMUMPS_FOUND true)
-    set(Scotch_parallel_FOUND true)
+    set(Scotch_PTScotch_FOUND true)
   endif()
 elseif(Scotch_esmumps_LIBRARY)
   set(Scotch_ESMUMPS_FOUND true)
@@ -95,16 +95,16 @@ HANDLE_COMPONENTS
 )
 
 if(Scotch_FOUND)
-set(Scotch_INCLUDE_DIRS ${Scotch_INCLUDE_DIR})
+  set(Scotch_INCLUDE_DIRS ${Scotch_INCLUDE_DIR})
 
-message(VERBOSE "Scotch libraries: ${Scotch_LIBRARIES}
-Scotch include directories: ${Scotch_INCLUDE_DIRS}")
+  message(VERBOSE "Scotch libraries: ${Scotch_LIBRARIES}
+  Scotch include directories: ${Scotch_INCLUDE_DIRS}")
 
-if(NOT TARGET Scotch::Scotch)
-  add_library(Scotch::Scotch INTERFACE IMPORTED)
-  set_property(TARGET Scotch::Scotch PROPERTY INTERFACE_LINK_LIBRARIES "${Scotch_LIBRARIES}")
-  set_property(TARGET Scotch::Scotch PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${Scotch_INCLUDE_DIR}")
-endif()
+  if(NOT TARGET Scotch::Scotch)
+    add_library(Scotch::Scotch INTERFACE IMPORTED)
+    set_property(TARGET Scotch::Scotch PROPERTY INTERFACE_LINK_LIBRARIES "${Scotch_LIBRARIES}")
+    set_property(TARGET Scotch::Scotch PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${Scotch_INCLUDE_DIR}")
+  endif()
 endif(Scotch_FOUND)
 
 mark_as_advanced(Scotch_INCLUDE_DIR)

--- a/options.cmake
+++ b/options.cmake
@@ -15,7 +15,7 @@ if(MUMPS_UPSTREAM_VERSION VERSION_LESS 5.7 AND NOT scalapack)
   message(FATAL_ERROR "MUMPS version < 5.7 requires scalapack=on")
 endif()
 
-option(scotch "use Scotch orderings ")
+option(scotch "use Scotch orderings")
 
 option(parmetis "use parallel METIS ordering")
 option(metis "use sequential METIS ordering")


### PR DESCRIPTION
Using `parallel` as a component in `FindMETIS.cmake` and `FindScotch.cmake` was causing issues because it is also a cache variable. This PR resolves that and allows me to build MUMPS with `-Dparmetis=ON`. In the future, `-Dptscotch=ON` should also work. I've also fixed a few minor whitespace consistency issues for indentation to match the rest of the package.

Resolves https://github.com/scivision/mumps/issues/75.