### PR TITLE
Allow users to set their own value for MKL_THREADING

### DIFF
--- a/cmake/FindSCALAPACK.cmake
+++ b/cmake/FindSCALAPACK.cmake
@@ -134,13 +134,15 @@ endif()
 
 # MKL_THREADING default: "intel_thread" which is Intel OpenMP
 # some systems have messed up OpenMP, so sequential unless requested
-if(TBB IN_LIST SCALAPACK_FIND_COMPONENTS)
-  set(MKL_THREADING "tbb_thread")
-elseif(OpenMP IN_LIST SCALAPACK_FIND_COMPONENTS)
-  set(MKL_THREADING "intel_thread")
-else()
-  set(MKL_THREADING "sequential")
-endif()
+if(NOT MKL_THREADING)
+  if(TBB IN_LIST SCALAPACK_FIND_COMPONENTS)
+    set(MKL_THREADING "tbb_thread")
+  elseif(OpenMP IN_LIST SCALAPACK_FIND_COMPONENTS)
+    set(MKL_THREADING "intel_thread")
+  else()
+    set(MKL_THREADING "sequential")
+  endif()
+endif(NOT MKL_THREADING)
 
 # default: dynamic
 if(STATIC IN_LIST SCALAPACK_FIND_COMPONENTS)


### PR DESCRIPTION
In my case, I need to use mkl_gnu_thread, so I would like to set manually MKL_THREADING and override the choice of FindScalapack.cmake. If MKL_THREADING is not set, the behaviour is unchanged.