### PR TITLE
Fix RPATH when building shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@ cmake_policy(SET CMP0168 OLD)
 # workaround to stop repeat FetchContent download on each configure for CMake 3.30.0..3.30.3
 endif()
 
+if(NOT APPLE)
+  set(CMAKE_INSTALL_RPATH $ORIGIN)
+endif()
+
 enable_testing()
 
 include(GNUInstallDirs)


### PR DESCRIPTION
This pull request fixes an issue where, when building the library as a shared library in Ubuntu, the `RPATH` was not being set. As a result, the linker could not locate the MUMPS::MUMPS dependencies at runtime.

To address this, the following lines were added to CMakeLists.txt:
```
if(NOT APPLE)
  set(CMAKE_INSTALL_RPATH $ORIGIN)
endif()
```

This change ensures that the runtime linker can resolve the dependencies relative to the location of the shared library, avoiding runtime errors when loading MUMPS from an external application.