### PR TITLE
Attempt to link correctly MUMPS in case of mixed use of shared libraries' generation and no parallel use of MUMPS on Apple Silicon

### DIFF
--- a/cmake/libseq.cmake
+++ b/cmake/libseq.cmake
@@ -17,7 +17,10 @@ target_include_directories(mpiseq_fortran PUBLIC
 "$<BUILD_INTERFACE:${MPI_Fortran_INCLUDE_DIRS}>"
 $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_compile_options(mpiseq_fortran PRIVATE ${mumps_fflags})
+target_compile_options(mpiseq_fortran PRIVATE ${mumps_fflags} )
+
+# Ensure linking mpi_fortran to mpi_c for missing symbol resolution
+target_link_libraries(mpiseq_fortran PUBLIC mpiseq_c)
 
 # we don't use this target directly, but it's to be compatible with other build systems that make a
 # libmpiseq file
@@ -36,4 +39,4 @@ add_library(MPI::MPI_C INTERFACE IMPORTED)
 target_link_libraries(MPI::MPI_C INTERFACE mpiseq_c)
 
 add_library(MPI::MPI_Fortran INTERFACE IMPORTED)
-target_link_libraries(MPI::MPI_Fortran INTERFACE mpiseq_fortran)
+target_link_libraries(MPI::MPI_Fortran INTERFACE mpiseq_fortran )

--- a/cmake/libseq.cmake
+++ b/cmake/libseq.cmake
@@ -17,7 +17,7 @@ target_include_directories(mpiseq_fortran PUBLIC
 "$<BUILD_INTERFACE:${MPI_Fortran_INCLUDE_DIRS}>"
 $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_compile_options(mpiseq_fortran PRIVATE ${mumps_fflags} )
+target_compile_options(mpiseq_fortran PRIVATE ${mumps_fflags})
 
 # Ensure linking mpi_fortran to mpi_c for missing symbol resolution
 target_link_libraries(mpiseq_fortran PUBLIC mpiseq_c)

--- a/cmake/libseq.cmake
+++ b/cmake/libseq.cmake
@@ -39,4 +39,4 @@ add_library(MPI::MPI_C INTERFACE IMPORTED)
 target_link_libraries(MPI::MPI_C INTERFACE mpiseq_c)
 
 add_library(MPI::MPI_Fortran INTERFACE IMPORTED)
-target_link_libraries(MPI::MPI_Fortran INTERFACE mpiseq_fortran )
+target_link_libraries(MPI::MPI_Fortran INTERFACE mpiseq_fortran)

--- a/cmake/mumps.cmake
+++ b/cmake/mumps.cmake
@@ -107,6 +107,8 @@ target_compile_definitions(mumps_common_Fortran PRIVATE ${mumps_fdefs})
 target_compile_options(mumps_common_Fortran PRIVATE ${mumps_fflags})
 
 add_library(mumps_common $<TARGET_OBJECTS:mumps_common_Fortran> $<TARGET_OBJECTS:mumps_common_C>)
+target_link_libraries(mumps_common PUBLIC MPI::MPI_C)
+target_link_libraries(mumps_common PUBLIC MPI::MPI_Fortran)
 
 set(BLAS_HAVE_GEMMT FALSE)
 if(BLAS_HAVE_sGEMMT OR BLAS_HAVE_dGEMMT OR BLAS_HAVE_cGEMMT OR BLAS_HAVE_zGEMMT)


### PR DESCRIPTION
Due to some linking errors ([see](https://github.com/scivision/mumps/issues/127)), I propose some very basic changes in in cmake configuration's files.  Note that, as I am not an expert at all on cmake and compilation processes, my changes must be carefully checked and validated.

The building process has been ran on Apple Silicon M3 only.