### PR TITLE
docs: document RPATH behavior in shared library builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ This CMake superbuild downloads the unmodified source tarfile from mumps-solver.
 
 Optional support for CUDA GPA and xKBLAS GPU-accelerated BLAS is [available](./Readme_options.md).
 
-CMake builds MUMPS quickly and more conveniently than the original Makefiles.
-CMake allows easy reuse of MUMPS in external projects via any of:
+CMake builds MUMPS quickly and more conveniently than the original Makefiles. CMake allows easy reuse of MUMPS in external projects via any of:
 
 * CMake [FetchContent](https://gist.github.com/scivision/2ad002ed26589783f1522160da4d27d1)
 * build MUMPS, `cmake --install`, then [find_package(MUMPS CONFIG REQUIRED)](https://gist.github.com/scivision/1ea2d19011c165b39b15ccb95d54f451)
@@ -42,6 +41,11 @@ See the
 and
 [MUMPS User Guide](https://mumps-solver.org/index.php?page=doc)
 for any questions about MUMPS itself.
+
+## Shared Libraries and Runtime Dependency Resolution
+
+When building shared libraries with `-DBUILD_SHARED_LIBS=on`, the installed MUMPS libraries include relative RPATH entries (`$ORIGIN`, `$ORIGIN/..`) that allow runtime dependencies to be resolved relative to the installation location.
+This ensures correct resolution of MUMPS dependencies (BLAS, MPI, Scotch, etc.) without requiring environment setup through modules or `LD_LIBRARY_PATH`, especially when MUMPS is used as a transitive dependency of another library.
 
 ## Build
 


### PR DESCRIPTION
## Overview
 This PR adds documentation to the README explaining the RPATH behavior in shared library builds, addressing the discussion raised in #63.
 
 ## Context
 In [Discussion #63](https://github.com/scivision/mumps-superbuild/discussions/63), the use case of MUMPS as a transitive dependency (where MUMPS is not directly linked to the final executable) was discussed. The concern was that without proper RPATH configuration, runtime dependency resolution could fail or resolve incorrect system libraries.
 
 ## Implementation Status
 The RPATH behavior has already been implemented in the main branch using relative paths (`$ORIGIN`, `$ORIGIN/..`), which enables robust runtime dependency resolution regardless of how deeply MUMPS is nested in the dependency graph.
 
 ## What This PR Adds
 A new section in README.md titled **"Shared Libraries and Runtime Dependency Resolution"** that explains:
 - When `-DBUILD_SHARED_LIBS=on` is used, MUMPS libraries include relative RPATH entries
 - How these entries enable dependency resolution relative to the installation location
 - Why this is particularly useful for transitive dependency scenarios
 - How it avoids the need for environment setup through modules or `LD_LIBRARY_PATH`
 
 ## Changes
 - `README.md`: Added documentation section for shared library RPATH behavior
 
 ## Resolves
 Addresses the documentation suggestion from [Discussion #63 - Suggestion](https://github.com/scivision/mumps-superbuild/discussions/63#discussioncomment-16192451)

------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------