### PR TITLE
Allow user to override url defined in libraries.json with -D

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,10 @@ if(MUMPS_gpu)
 
 # https://cmake.org/cmake/help/latest/module/FindCUDAToolkit.html
   if(MUMPS_xkblas)
-    string(JSON xkblas_url GET "${json}" "xkblas")
+    # Check if 'xkblas_url' hasn't been defined by the user (with -D)
+    if(NOT DEFINED xkblas_url)
+      string(JSON xkblas_url GET "${json}" "xkblas")
+    endif()
 
     # FIXME: in the future as users contribute, we could adapt to NVHPC, etc.
     set(KAAPI_USE_CUDA_RT true)
@@ -260,10 +263,13 @@ if(MUMPS_metis OR MUMPS_parmetis)
     set(_metis_components)
   endif()
 
-  if(MUMPS_parmetis)
-    string(JSON metis_url GET "${json}" "parmetis")
-  else()
-    string(JSON metis_url GET "${json}" "metis")
+  # Check if 'metis_url' hasn't been defined by the user (with -D)
+  if(NOT DEFINED metis_url)
+    if(MUMPS_parmetis)
+      string(JSON metis_url GET "${json}" "parmetis")
+    else()
+      string(JSON metis_url GET "${json}" "metis")
+    endif()
   endif()
 
   FetchContent_Declare(mumps_metis

--- a/cmake/scalapack.cmake
+++ b/cmake/scalapack.cmake
@@ -35,7 +35,10 @@ endif()
 set(SCALAPACK_BUILD_TESTING off)
 set(SCALAPACK_BUILD_TESTS off)
 
-string(JSON scalapack_url GET "${json}" "scalapack")
+# Check if 'scalapack_url' hasn't been defined by the user (with -D)
+if(NOT DEFINED scalapack_url)
+  string(JSON scalapack_url GET "${json}" "scalapack")
+endif()
 
 if(CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM" OR CMAKE_C_COMPILER_ID STREQUAL "IntelLLVM")
   # oneAPI must use MKL, it will fail to build Netlib SCALAPACK

--- a/cmake/scotch.cmake
+++ b/cmake/scotch.cmake
@@ -64,7 +64,10 @@ set(CMAKE_POSITION_INDEPENDENT_CODE true)
 
 if(WIN32 AND (NOT BISON_ROOT OR NOT FLEX_ROOT))
 
-  string(JSON win_flex_bison_url GET "${json}" win_flex_bison url)
+  # Check if 'win_flex_bison_url' hasn't been defined by the user (with -D)
+  if(NOT DEFINED win_flex_bison_url)
+    string(JSON win_flex_bison_url GET "${json}" win_flex_bison url)
+  endif()
 
   FetchContent_Declare(win_flex_bison URL ${win_flex_bison_url})
   FetchContent_MakeAvailable(win_flex_bison)
@@ -92,7 +95,10 @@ if(NOT DEFINED CMAKE_POLICY_VERSION_MINIMUM)
   set(CMAKE_POLICY_VERSION_MINIMUM ${CMAKE_MINIMUM_REQUIRED_VERSION})
 endif()
 
-string(JSON scotch_url GET "${json}" "scotch")
+# Check if 'scotch_url' hasn't been defined by the user (with -D)
+if(NOT DEFINED scotch_url)
+  string(JSON scotch_url GET "${json}" "scotch")
+endif()
 
 message(STATUS "BISON_ROOT ${BISON_ROOT}  FLEX_ROOT ${FLEX_ROOT}")
 


### PR DESCRIPTION
Typically, I cannot download `https://github.com/Reference-ScaLAPACK/scalapack/archive/8ea5880a448cd24622dff95fd1b7394c31e61bda.tar.gz` because of firewalls, but I can place it somewhere else.
So I propose this patch, in order to be able to pass `-Dscalapack_url=http://myadress` to `cmake` (and for scotch, xkblas, etc.)