### PR TITLE
Add option -DMUMPS_avx512vbmi (OFF by default)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,23 @@ if(MUMPS_gemmt)
   endif()
 endif()
 
+# AVX512 VBMI instruction set accelerates adaptive precision with BLR (starting with mumps 5.9.0)
+if(MUMPS_ACTUAL_VERSION VERSION_GREATER_EQUAL 5.9.0 AND MUMPS_avx512vbmi)
+  include(cmake/avx512vbmi.cmake)
+  if(HAVE_AVX512VBMI)
+    message(STATUS "AVX-512 VBMI support detected.")
+    list(APPEND mumps_fdefs USE_AVX512_VBMI)
+    list(APPEND mumps_cdefs USE_AVX512_VBMI)
+    if(MSVC)
+        add_compile_options("$<$<COMPILE_LANGUAGE:C>:/arch:AVX512>")
+    else()
+        add_compile_options("$<$<COMPILE_LANGUAGE:C>:-mavx512vbmi;-mavx512vl>")
+    endif()
+  else()
+    message(FATAL_ERROR "The compiler does not support AVX-512 VBMI.")
+  endif()
+endif()
+
 # --- ordering libs
 
 set(ORDERING_DEFS pord)

--- a/Readme_options.md
+++ b/Readme_options.md
@@ -98,6 +98,18 @@ Default is OpenMP OFF.
 cmake -DMUMPS_openmp=on
 ```
 
+## AVX512
+
+MUMPS can take profit from avx512 vbmi (Vector Byte Manipulation Instructions) instruction set to speed-up compression and decompression when using BLR with adaptive precision.
+This option `MUMPS_avx512vbmi=true` will activate this feature (if your compiler handles it). There is no execution test, so you can enable
+it on a machine that doesn't handle this instruction set (but you wont be able to run this build of mumps locally).
+Default is avx512 vbmi OFF.
+
+```sh
+cmake -DMUMPS_avx512vbmi=on
+```
+
+
 ---
 
 [Matlab](./Readme_matlab.md) can use MUMPS library as well.

--- a/cmake/avx512vbmi.cmake
+++ b/cmake/avx512vbmi.cmake
@@ -1,0 +1,30 @@
+include(CheckCCompilerFlag)
+include(CheckCSourceCompiles)
+
+# 1. Test flag acceptance (GCC/Clang syntax)
+check_c_compiler_flag("-mavx512vbmi" COMPILER_SUPPORTS_AVX512VBMI)
+
+# Prepare required flags for the compilation test
+set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+if(COMPILER_SUPPORTS_AVX512VBMI)
+    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -mavx512vbmi")
+elseif(MSVC)
+    # MSVC has no specific flag for VBMI, everything is under /arch:AVX512
+    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} /arch:AVX512")
+endif()
+
+# 2. Test if code using AVX-512 VBMI actually compiles
+check_c_source_compiles("
+    #include <immintrin.h>
+    int main() {
+        __m512i index = _mm512_setzero_si512();
+        __m512i data = _mm512_setzero_si512();
+        // _mm512_permutexvar_epi8 is specific to AVX512-VBMI
+        __m512i result = _mm512_permutexvar_epi8(index, data);
+        return 0;
+    }
+" HAVE_AVX512VBMI)
+
+# Restore global flags
+set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+

--- a/options.cmake
+++ b/options.cmake
@@ -4,6 +4,8 @@ option(MUMPS_find_static "Find static libraries for Lapack and Scalapack (defaul
 
 option(MUMPS_gemmt "GEMMT is recommended in MUMPS User Manual if available" ON)
 
+option(MUMPS_avx512vbmi "AVX512 VBMI instruction set accelerates adaptive precision with BLR" OFF)
+
 option(MUMPS_parallel "parallel (use MPI)" ON)
 option(MUMPS_scalapack "Use ScalaPACK to speed up the solution of linear systems" ON)
 


### PR DESCRIPTION
AVX512 VBMI instruction set is used in mumps BLR to speed-up adaptive precision feature. If ON, we test the support of avx512 vbmi at compilation, not at execution.

I only tested with gcc & linux. A more accurate test could be to try and compile mumps_flytes.c directly, but as it is it works with 5.9.1