### PR TITLE
Fix Visual Studio generator build with oneAPI

### DIFF
--- a/Readme_Windows.md
+++ b/Readme_Windows.md
@@ -86,3 +86,25 @@ Optionally, run self-tests:
 ```sh
 ctest --test-dir build
 ```
+
+## Visual Studio generator
+
+Ninja is the smoother path and is what the presets use. If Visual Studio project files are
+wanted, select the Fortran toolset and let CMake pick MSVC `cl` for C:
+
+```sh
+cmake -B build -G "Visual Studio 17 2022" -A x64 -T fortran=ifx
+
+cmake --build build --config Release
+```
+
+Three things differ from the Ninja generator:
+
+* MSBuild does not preprocess `*.F` / `*.F90`, whereas CMake preprocesses them itself for the
+  Ninja Fortran module dependency scanner. `cmake/compilers.cmake` adds `/fpp` for this
+  generator; without it the build fails with misleading errors #5082, #6333, #6417 and #5508.
+* Targets built only from `$<TARGET_OBJECTS:>` are linked by link.exe rather than ifx, and
+  MSBuild's `LIB` does not cover the Intel Fortran runtime. `cmake/compilers.cmake` adds the
+  oneAPI compiler `lib` directory to the linker search path.
+* ALL_BUILD is a `.vcxproj` and cannot depend on a Fortran `.vfproj`, so a Fortran target that
+  no other target links is never built. Give such targets `LINKER_LANGUAGE C`.

--- a/cmake/compilers.cmake
+++ b/cmake/compilers.cmake
@@ -74,6 +74,31 @@ if(MUMPS_intsize64)
   endif()
 endif()
 
+if(WIN32 AND CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM" AND CMAKE_GENERATOR MATCHES "Visual Studio")
+  # MSBuild does not run the preprocessor on *.F / *.F90. The Ninja generator does not need this,
+  # as CMake preprocesses Fortran itself there to scan module dependencies. Without /fpp the
+  # #if / #else in the MUMPS sources are compiled as ordinary source lines, and the build fails
+  # with misleading errors: #5082, #6333, #6417, #5508.
+  string(APPEND CMAKE_Fortran_FLAGS " /fpp")
+
+  # mumps_common, mpiseq and the arithmetic libraries have no sources of their own, only
+  # $<TARGET_OBJECTS:>, so CMake links them with link.exe rather than ifx. Under MSBuild the LIB
+  # environment variable only covers the Visual Studio toolset, so the Intel Fortran runtime
+  # (ifconsol.lib, ifmodintr.lib, ...) is not found. A Ninja build started from an oneAPI command
+  # prompt already has that directory in LIB.
+  # Keep forward slashes: the Visual Studio generator turns /LIBPATH: into
+  # <AdditionalLibraryDirectories> and drops backslashes on the way.
+  cmake_path(GET CMAKE_Fortran_COMPILER PARENT_PATH _ifx_dir)
+  cmake_path(GET _ifx_dir PARENT_PATH _ifx_root)
+  if(IS_DIRECTORY "${_ifx_root}/lib")
+    foreach(t IN ITEMS EXE SHARED MODULE)
+      string(APPEND CMAKE_${t}_LINKER_FLAGS " \"/LIBPATH:${_ifx_root}/lib\"")
+    endforeach()
+  else()
+    message(WARNING "MUMPS: Intel Fortran runtime libraries not found under ${_ifx_root}/lib, linking may fail")
+  endif()
+endif()
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 
 # Necessary for shared library with Visual Studio / Windows oneAPI


### PR DESCRIPTION
`Readme_oneapi.md` documents the Visual Studio generator:

```sh
cmake -Bbuild -G "Visual Studio 17 2022" -T fortran=ifx
```

That configuration does not build. Two problems, both specific to this generator.

### MSBuild does not preprocess `*.F` / `*.F90`

The Ninja generator does not need an explicit flag, because CMake preprocesses Fortran itself
there to scan module dependencies — you can see the `*-pp.f` files it produces. MSBuild does
not, so the `#if` / `#else` in the MUMPS sources are compiled as ordinary source lines.

The resulting errors point nowhere near the cause. `bcast_errors.F` compiles both branches of an
`#if` / `#else` and reports:

```
bcast_errors.F(23): error #6417: The dimensions of this array have been defined more than once. [IN]
```

Similarly `ana_orderings.F` reports #6333, `sol_common.F` #5082 and `lr_common.F` #5508.

### The Intel Fortran runtime is not on the linker search path

`mumps_common`, `mpiseq` and the arithmetic libraries have no sources of their own, only
`$<TARGET_OBJECTS:>`, so CMake links them with link.exe rather than ifx. Under MSBuild the `LIB`
environment variable only covers the Visual Studio toolset:

```
LINK : fatal error LNK1104: cannot open file 'ifconsol.lib'
LINK : fatal error LNK1104: cannot open file 'ifmodintr.lib'
```

A Ninja build started from an oneAPI command prompt already has that directory in `LIB`, so both
changes are scoped to `CMAKE_GENERATOR MATCHES "Visual Studio"` and the Ninja path is untouched.

### Testing

Windows 11, ifx 2026.1.1, MSVC cl 19.51, CMake 4.4.2, oneMKL 2026.1.

| Generator | Configuration | ctest |
| --- | --- | --- |
| Visual Studio 18 2026 | sequential, 4 precisions, METIS | 6/6 |
| Ninja | sequential, 4 precisions, METIS | 6/6 |
| Ninja | parallel, Intel MPI + oneMKL ScaLAPACK | 6/6 |

The parallel run executes four of the six tests under `mpiexec -n 2`; the solver was also
checked by hand on 4 ranks.
