### PR TITLE
Add MUMPS_dll to build a single shared library on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,6 +308,10 @@ ${mumps_upstream_SOURCE_DIR}/src/CMakeLists.txt
 COPYONLY)
 add_subdirectory(${mumps_upstream_SOURCE_DIR}/src src)
 
+if(MUMPS_dll)
+  include(cmake/dll.cmake)
+endif()
+
 if(MUMPS_matlab)
   configure_file(cmake/matlab.cmake
   ${mumps_upstream_SOURCE_DIR}/MATLAB/CMakeLists.txt

--- a/Readme_Windows.md
+++ b/Readme_Windows.md
@@ -86,3 +86,23 @@ Optionally, run self-tests:
 ```sh
 ctest --test-dir build
 ```
+
+## Shared library
+
+`BUILD_SHARED_LIBS=on` builds one DLL per library, which does not link with the Windows oneAPI
+compilers. ifx emits Fortran module variables as COMMON symbols:
+`CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` cannot export those, and Fortran cannot import them without
+an explicit `DLLIMPORT` attribute in the MUMPS sources. `dmumps` then fails to resolve the
+`MUMPS_BUF_COMMON` and `MUMPS_LR_COMMON` module data that lives in `mumps_common`.
+
+Build the component libraries static and bundle every object into a single `mumps.dll` instead:
+
+```sh
+cmake -B build -DBUILD_SHARED_LIBS=off -DMUMPS_dll=on
+
+cmake --build build
+```
+
+Those references then stay inside the DLL. Only the C API -- `smumps_c`, `dmumps_c`,
+`cmumps_c`, `zmumps_c` -- and the Fortran entry points are exported; PORD, METIS and the module
+data remain internal. Link against `mumps.lib` as usual.

--- a/cmake/dll.cmake
+++ b/cmake/dll.cmake
@@ -1,0 +1,68 @@
+# --- Single Windows DLL
+#
+# ifx emits Fortran module variables as COMMON symbols. Those cannot be exported from a DLL
+# by CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS, and Fortran has no way to import them short of an
+# explicit !DIR$ ATTRIBUTES DLLIMPORT in the MUMPS sources. Splitting MUMPS over one DLL per
+# library therefore fails to link: dmumps references MUMPS_BUF_COMMON / MUMPS_LR_COMMON module
+# data that lives in mumps_common.
+#
+# Bundling every object into one shared library keeps those references inside the DLL, so only
+# the C API (dmumps_c, smumps_c, ...) and the Fortran entry points need to be exported.
+# Build the component libraries static (BUILD_SHARED_LIBS=off) and turn this on instead.
+
+set(_mumps_dll_objs
+$<TARGET_OBJECTS:mumps_common_C>
+$<TARGET_OBJECTS:mumps_common_Fortran>
+$<TARGET_OBJECTS:pord>
+)
+
+if(NOT MUMPS_parallel)
+  list(APPEND _mumps_dll_objs $<TARGET_OBJECTS:mpiseq_c> $<TARGET_OBJECTS:mpiseq_fortran>)
+endif()
+
+foreach(a IN ITEMS s d c z)
+  if(TARGET ${a}mumps)
+    list(APPEND _mumps_dll_objs $<TARGET_OBJECTS:${a}mumps_C> $<TARGET_OBJECTS:${a}mumps_Fortran>)
+  endif()
+endforeach()
+
+add_library(mumps_dll SHARED ${_mumps_dll_objs})
+
+target_include_directories(mumps_dll PUBLIC
+"$<BUILD_INTERFACE:${mumps_upstream_SOURCE_DIR}/include>"
+$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+# mpiseq / pord / the arithmetic objects are already inside the DLL, so only the external
+# dependencies are linked here.
+target_link_libraries(mumps_dll PRIVATE
+LAPACK::LAPACK
+$<$<AND:$<BOOL:${MUMPS_scalapack}>,$<BOOL:${MUMPS_parallel}>>:SCALAPACK::SCALAPACK>
+"$<$<BOOL:${MUMPS_parallel}>:MPI::MPI_Fortran;MPI::MPI_C>"
+$<$<BOOL:${MUMPS_parmetis}>:PARMETIS::PARMETIS>
+$<$<BOOL:${MUMPS_metis}>:METIS::METIS>
+"$<$<BOOL:${MUMPS_openmp}>:OpenMP::OpenMP_Fortran;OpenMP::OpenMP_C>"
+"$<$<BOOL:${MUMPS_gpu}>:CUDA::cublas;CUDA::cudart>"
+$<$<BOOL:${MUMPS_xkblas}>:xkblas::xkblas>
+$<$<BOOL:${IMPI_LIB64}>:${IMPI_LIB64}>
+${CMAKE_THREAD_LIBS_INIT}
+)
+
+set_target_properties(mumps_dll PROPERTIES
+OUTPUT_NAME mumps
+EXPORT_NAME DLL
+# C rather than Fortran so this becomes a .vcxproj: the Visual Studio generator cannot make
+# ALL_BUILD (a .vcxproj) depend on a Fortran .vfproj, so a leaf .vfproj target is never built.
+# link.exe picks up the Intel Fortran runtime from the /DEFAULTLIB directives in the objects,
+# helped by the /LIBPATH added in cmake/compilers.cmake.
+LINKER_LANGUAGE C
+WINDOWS_EXPORT_ALL_SYMBOLS ON
+VERSION ${MUMPS_ACTUAL_VERSION}
+RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
+LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib
+ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib
+)
+
+add_library(MUMPS::DLL ALIAS mumps_dll)
+
+install(TARGETS mumps_dll EXPORT ${PROJECT_NAME}-targets)

--- a/options.cmake
+++ b/options.cmake
@@ -40,6 +40,12 @@ endif()
 
 option(BUILD_SHARED_LIBS "Build shared libraries")
 
+option(MUMPS_dll "Bundle every MUMPS object into a single shared library -- the way to get a DLL on Windows, see cmake/dll.cmake")
+if(MUMPS_dll AND BUILD_SHARED_LIBS)
+  message(FATAL_ERROR "MUMPS_dll bundles the component libraries into one shared library, so they must be static:
+  cmake -DMUMPS_dll=on -DBUILD_SHARED_LIBS=off")
+endif()
+
 # fPIC flags are specified by MUMPS INSTALL file, so we do the same in CMake
 include(CheckPIESupported)
 check_pie_supported()


### PR DESCRIPTION
`CMakeLists.txt` warns that `BUILD_SHARED_LIBS=on` with the Windows oneAPI compilers "is not
supported and will probably fail", without saying why. This is the why, and a way around it.

### Root cause

ifx emits Fortran module variables as COMMON symbols:

```
$ llvm-nm --defined-only mumps_common_Fortran.dir/lr_common.F.obj
00000008 C MUMPS_LR_COMMON_mp_NPREC_STOC
00000060 C MUMPS_BUF_COMMON_mp_BUF_CB
```

`CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` skips COMMON symbols when generating the `.def`, and Fortran
cannot import them without an explicit `DLLIMPORT` attribute in the MUMPS sources. So
`dmumps.dll` cannot resolve the module data that lives in `mumps_common.dll`:

```
dmumps_comm_buffer.obj : error LNK2019: unresolved external symbol MUMPS_BUF_COMMON_mp_BUF_CB
dlr_type.obj : error LNK2001: unresolved external symbol MUMPS_LR_COMMON_mp_NPREC_STOC
```

What breaks is splitting MUMPS across several DLLs, not shared linkage as such.

### Approach

`MUMPS_dll` keeps the component libraries static and bundles their objects into one shared
library, so the module data references never cross a DLL boundary:

```sh
cmake -B build -DBUILD_SHARED_LIBS=off -DMUMPS_dll=on
```

Only the C API and the Fortran entry points are exported — 4042 symbols, including `smumps_c`,
`dmumps_c`, `cmumps_c` and `zmumps_c`. PORD, METIS and the module data stay internal.

The bundling target carries `LINKER_LANGUAGE C` deliberately: the Visual Studio generator cannot
make ALL_BUILD, a `.vcxproj`, depend on a Fortran `.vfproj`, so a Fortran-linked target that
nothing else links is silently never built.

### Testing

Windows 11, ifx 2026.1.1, MSVC cl, oneMKL 2026.1. Ninja and Visual Studio 18 2026, sequential
and parallel, all four precisions, PORD and METIS: ctest 6/6 everywhere. A C program compiled
with `cl` and linked against `mumps.lib` solves correctly through `mumps.dll`.

Not exercised on Linux or macOS, where `BUILD_SHARED_LIBS` already works — the option is a
Windows workaround, though nothing in it is Windows-specific.

Happy to reduce this to just the diagnosis if you would rather shape the option differently, or
turn it into an issue instead.
