### PR TITLE
Fix Fortran name-mangling default: `Add_` is Linux-only, Windows needs `UPPER`

### DIFF
--- a/cmake/compilers.cmake
+++ b/cmake/compilers.cmake
@@ -7,8 +7,14 @@ set(mumps_cflags)
 set(mumps_fflags -w)
 # lets project consuming MUMPS not have excessive warnings from MUMPS sources
 
-list(APPEND mumps_cdefs "$<$<COMPILE_LANGUAGE:C>:Add_>")
-# "Add_" works for all modern compilers we tried.
+# "Add_" (trailing underscore) is the Fortran name-mangling convention used
+# by GNU/Intel Fortran on Linux, but not on Windows, where the convention is
+# "UPPER" (uppercase, no underscore). Unconditionally defining "Add_" broke
+# name mangling between the C and Fortran sources on Windows. Select the
+# convention based on platform instead of assuming "Add_" universally.
+list(APPEND mumps_cdefs "$<$<AND:$<COMPILE_LANGUAGE:C>,$<BOOL:${UNIX}>>:Add_>")
+list(APPEND mumps_cdefs "$<$<AND:$<COMPILE_LANGUAGE:C>,$<BOOL:${WIN32}>>:UPPER>")
+
 
 if(MSVC)
   list(APPEND mumps_cdefs _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE)


### PR DESCRIPTION
`cmake/compilers.cmake` unconditionally defines the C preprocessor macro `Add_` for all platforms:

```cmake
list(APPEND mumps_cdefs "$<$<COMPILE_LANGUAGE:C>:Add_>")
# "Add_" works for all modern compilers we tried.
```

This macro controls how MUMPS' C wrapper code (`mumps_c_types.h` / the C↔Fortran calling-convention glue) constructs the symbol names it uses to call into the Fortran routines. `Add_` tells the C code to expect Fortran symbols with a trailing underscore appended (e.g. `dmumps_` for `DMUMPS`), which is the convention `gfortran`/`ifort` use on Linux.

However, this convention is **not universal**: on Windows, GNU/Intel Fortran compilers mangle external symbols by uppercasing the name with **no trailing underscore** (`DMUMPS`, not `dmumps_`). Since `Add_` is defined unconditionally regardless of platform, the C wrapper code on Windows builds looks for symbols with a trailing underscore that the Fortran object files never actually export, causing unresolved-symbol link errors (or, worse, silent symbol-name mismatches that the linker may resolve incorrectly against unrelated symbols, depending on the specific compiler/linker combination).

## Fix

Make the macro selection conditional on platform instead of hardcoding `Add_`:

```cmake
list(APPEND mumps_cdefs "$<$<AND:$<COMPILE_LANGUAGE:C>,$<BOOL:${UNIX}>>:Add_>")
list(APPEND mumps_cdefs "$<$<AND:$<COMPILE_LANGUAGE:C>,$<BOOL:${WIN32}>>:UPPER>")
```

- On UNIX-like systems (Linux/macOS): keep defining `Add_` (unchanged behavior, matches existing tested convention).
- On Windows: define `UPPER` instead, matching the actual name-mangling convention used by Windows Fortran compilers (MSVC+ifort, ifx, etc.).

Both defines use CMake generator expressions gated on `COMPILE_LANGUAGE:C`, exactly as the line they replace did, so this only affects how the C sources are compiled — no change to Fortran compilation flags.

## Why this matters upstream

This isn't a project-specific workaround — it's a portability bug in how MUMPS' C interface layer is configured for any consumer building on Windows with the CMake superbuild. Any downstream project cross-compiling or natively building MUMPS on Windows would hit the same symbol-mangling mismatch.
