### PR TITLE
Link `Threads::Threads` explicitly on MUMPS targets instead of relying on transitive pthread linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,6 +308,23 @@ ${mumps_upstream_SOURCE_DIR}/src/CMakeLists.txt
 COPYONLY)
 add_subdirectory(${mumps_upstream_SOURCE_DIR}/src src)
 
+# Several MUMPS Fortran/C sources call pthread APIs directly (e.g. for
+# I/O locking / OpenMP-adjacent synchronization), but none of the MUMPS
+# targets explicitly link Threads::Threads, only relying on it being
+# pulled in transitively by whichever BLAS/LAPACK/SCALAPACK/MPI backend
+# happens to depend on pthread. Some backends (e.g. a shared OpenBLAS, or
+# certain MPI implementations) don't expose that dependency transitively,
+# leaving these symbols unresolved at link time on those configurations.
+# Link Threads::Threads directly on the MUMPS targets so the pthread
+# symbols they use are always resolved regardless of backend.
+if(Threads_FOUND)
+  foreach(tgt MUMPS::COMMON MUMPS::SMUMPS MUMPS::DMUMPS MUMPS::CMUMPS MUMPS::ZMUMPS MUMPS::PORD)
+    if(TARGET ${tgt})
+      target_link_libraries(${tgt} INTERFACE Threads::Threads)
+    endif()
+  endforeach()
+endif()
+
 if(MUMPS_matlab)
   configure_file(cmake/matlab.cmake
   ${mumps_upstream_SOURCE_DIR}/MATLAB/CMakeLists.txt


### PR DESCRIPTION
## Problem

Several MUMPS C/Fortran sources call POSIX threads APIs directly — most notably `mumps_io_thread.c` and `mumps_register_thread.c`, which use `pthread_mutex_lock`/`pthread_mutex_unlock`, `pthread_cond_wait`/`pthread_cond_signal`, `pthread_create`, etc. for the asynchronous I/O and out-of-core (OOC) subsystems.

None of the MUMPS CMake targets (`MUMPS::COMMON`, `MUMPS::SMUMPS`, `MUMPS::DMUMPS`, `MUMPS::CMUMPS`, `MUMPS::ZMUMPS`, `MUMPS::PORD`) explicitly link `Threads::Threads`. The build currently only succeeds because pthread happens to be pulled in **transitively** by whatever BLAS/LAPACK/SCALAPACK/MPI backend is selected:

- GCC's OpenMP runtime (`libgomp`) automatically adds `-lpthread` whenever `-fopenmp` is used, so any build with `MUMPS_openmp=ON` and a GCC-family compiler incidentally gets pthread linked even without an explicit request.
- Some BLAS/LAPACK `find_package()` results append `-lpthread` to `LAPACK_LIBRARIES` as a side effect of their own internal link-checks.
- Certain MPI implementations' shared libraries (`libmpi.so`) themselves depend on `libpthread.so.0`, which also transitively drags it in.

This is fragile: it depends entirely on implementation details of *other* dependencies that MUMPS doesn't control and that can legitimately change (a different MPI vendor, a BLAS backend that doesn't need pthread internally, a non-GCC compiler paired with an OpenMP runtime that — unlike `libgomp` — does *not* auto-link pthread, e.g. LLVM's `libomp`). In any configuration where none of these incidental paths happen to supply `-lpthread`, the final link will fail with unresolved `pthread_*` symbols coming from MUMPS' own object files.

## Fix

Link `Threads::Threads` directly (as a public/`INTERFACE` dependency) on the MUMPS component targets, guarded by `Threads_FOUND` (already discovered earlier in the superbuild via the existing `find_package(Threads)` call) and by `if(TARGET ...)` checks so it only applies to targets that actually exist for the current configuration:

```cmake
if(Threads_FOUND)
  foreach(tgt MUMPS::COMMON MUMPS::SMUMPS MUMPS::DMUMPS MUMPS::CMUMPS MUMPS::ZMUMPS MUMPS::PORD)
    if(TARGET ${tgt})
      target_link_libraries(${tgt} INTERFACE Threads::Threads)
    endif()
  endforeach()
endif()
```

This makes the pthread dependency explicit and self-contained instead of accidental, matching CMake's own recommended practice (`find_package(Threads)` + `Threads::Threads`) for any target that calls pthread APIs directly.

## Why this matters upstream

This is not a project-specific workaround — it's a general correctness/robustness fix for the superbuild's own `CMakeLists.txt`. Any consumer of this CMake superbuild that combines MUMPS with a BLAS/MPI/compiler stack that doesn't happen to transitively supply pthread (for example, a toolchain using LLVM's `libomp` instead of GCC's `libgomp` — `libomp` does not automatically add `-lpthread` to the link the way `libgomp` does) would hit unresolved `pthread_*` symbol errors at link time, with no CMake-level indication of why. Declaring the dependency explicitly removes this class of failure for every downstream consumer.