### PR TITLE
FindLAPACK/FindSCALAPACK: use MUMPS_find_static, not BUILD_SHARED_LIBS

### DIFF
--- a/cmake/FindLAPACK.cmake
+++ b/cmake/FindLAPACK.cmake
@@ -280,7 +280,11 @@ function(lapack_aocl)
 
 set(_names flame)
 if(WIN32)
-  if(BUILD_SHARED_LIBS)
+  # Use MUMPS_find_static (the project's own static/shared search toggle)
+  # rather than BUILD_SHARED_LIBS: whether MUMPS builds
+  # shared libraries is unrelated to whether AOCL's Flame library should be
+  # searched for as a static or shared/dll library.
+  if(NOT MUMPS_find_static)
     list(APPEND _names AOCL-LibFlame-Win-MT-dll AOCL-LibFlame-Win-dll)
   else()
     list(APPEND _names AOCL-LibFlame-Win-MT AOCL-LibFlame-Win)
@@ -319,7 +323,9 @@ endif()
 
 set(_names blis-mt blis)
 if(WIN32)
-  if(BUILD_SHARED_LIBS)
+  # Same rationale as above: use MUMPS_find_static, not BUILD_SHARED_LIBS,
+  # to pick the AOCL Blis (BLAS) library naming variant to search for.
+  if(NOT MUMPS_find_static)
     list(APPEND _names AOCL-LibBlis-Win-MT-dll AOCL-LibBlis-Win-dll)
   else()
     list(APPEND _names AOCL-LibBlis-Win-MT AOCL-LibBlis-Win)

--- a/cmake/FindSCALAPACK.cmake
+++ b/cmake/FindSCALAPACK.cmake
@@ -219,7 +219,11 @@ endfunction()
 
 function(scalapack_netlib)
 
-if(BUILD_SHARED_LIBS)
+# Use MUMPS_find_static (the project's own static/shared search toggle)
+# rather than BUILD_SHARED_LIBS: whether MUMPS builds
+# shared libraries is unrelated to whether SCALAPACK itself should be
+# searched for as a static or shared library.
+if(NOT MUMPS_find_static)
   set(_s shared)
 else()
   set(_s static)


### PR DESCRIPTION
## Problem

`FindLAPACK.cmake` (AOCL Flame/Blis Windows library naming) and `FindSCALAPACK.cmake` (`scalapack_netlib()`) currently branch on `BUILD_SHARED_LIBS` to decide whether to search for the *shared/dll* or *static* variant of AOCL/SCALAPACK library names:

```cmake
if(BUILD_SHARED_LIBS)
  list(APPEND _names AOCL-LibFlame-Win-MT-dll AOCL-LibFlame-Win-dll)
else()
  list(APPEND _names AOCL-LibFlame-Win-MT AOCL-LibFlame-Win)
endif()
```

`BUILD_SHARED_LIBS` controls whether **MUMPS itself** is built as a shared or static library. It has no logical connection to which *variant of an already-built third-party dependency* (AOCL, SCALAPACK) should be searched for on disk -- those are two independent decisions. A project can legitimately want to build MUMPS as a shared library while still linking it against static AOCL/SCALAPACK archives, or vice versa.

This project already has the right variable for this decision: `MUMPS_find_static` (introduced upstream, `option(MUMPS_find_static "Find static libraries for Lapack and Scalapack ...")`, already used in `cmake/lapack.cmake` and `cmake/scalapack.cmake` to append `STATIC` to `LAPACK_VENDOR`/`SCALAPACK_VENDOR`). The three call sites above are simply the last remaining spots where `BUILD_SHARED_LIBS` slipped in instead.

## Fix

Replace the three `if(BUILD_SHARED_LIBS)` checks (2x `FindLAPACK.cmake` AOCL naming, 1x `FindSCALAPACK.cmake` netlib naming) with `if(NOT MUMPS_find_static)`, aligning them with the rest of the codebase's existing use of `MUMPS_find_static` for this exact purpose.
